### PR TITLE
fix(README): replace 2024 with 2025 for Android 15 page size deadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Go CLI tool to check if your Android APK is ready for Google's 16KB page size 
 
 ## Background
 
-Starting **November 1, 2024**, Google Play Console requires all apps targeting Android 15 to support 16KB page sizes. This tool quickly analyzes your APK's native libraries (ARM64/x86_64) to verify ELF alignment compatibility.
+Starting **November 1, 2025**, Google Play Console requires all apps targeting Android 15 to support 16KB page sizes. This tool quickly analyzes your APK's native libraries (ARM64/x86_64) to verify ELF alignment compatibility.
 
 ## Installation
 


### PR DESCRIPTION
Update README to the correct transition deadline (Nov 1, 2025) for Android 15 16KB page size support.  

Ref: [Android Developers – Page sizes](https://developer.android.com/guide/practices/page-sizes?utm_source=chatgpt.com)